### PR TITLE
Typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "Normalizes GraphQL responses by reducing duplication, resulting in smaller payloads and faster JSON parsing.",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test": "jest --coverage",
     "watch": "jest --watchAll --coverage"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,5 @@
 declare module 'graphql-crunch' {
-  export type Uncrunched =
-    | { [key: string]: any }
-    | Array<{ [key: string]: any }>
-
-  export type Crunched = Array<
+  export type CrunchedData = Array<
     | null
     | number
     | string
@@ -12,7 +8,7 @@ declare module 'graphql-crunch' {
     | number[]
   >
 
-  export function crunch(data: Uncrunched): Crunched
+  export function crunch(data: any): CrunchedData
 
-  export function uncrunch(data: Crunched): Uncrunched
+  export function uncrunch(data: CrunchedData): any
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'graphql-crunch' {
+  export function crunch(data: object | object[]): any[]
+
+  export function uncrunch(data: any[]): object | object[]
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,18 @@
 declare module 'graphql-crunch' {
-  export function crunch(data: object | object[]): any[]
+  export type Uncrunched =
+    | { [key: string]: any }
+    | Array<{ [key: string]: any }>
 
-  export function uncrunch(data: any[]): object | object[]
+  export type Crunched = Array<
+    | null
+    | number
+    | string
+    | boolean
+    | { [key: string]: number }
+    | number[]
+  >
+
+  export function crunch(data: Uncrunched): Crunched
+
+  export function uncrunch(data: Crunched): Uncrunched
 }


### PR DESCRIPTION
The following types are very basic but is enough, the `data` in a graphql response is typed as `object`.