### PR TITLE
Remove `__schema` check from README example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -318,7 +318,7 @@ we recommend conditioning the crunch on a query param, like so:
 app.use('/graphql', graphqlExpress((request) => {
   return {
     formatResponse: (response) => {
-      if(request.query.crunch && response.data && !response.data.__schema) {
+      if (request.query.crunch && response.data) {
         response.data = crunch(response.data);
       }
 


### PR DESCRIPTION
@stevekrenzel, I'm 99.9% certain that this was just cargo-culted from `graphql-deduplicator` and doesn't need to be in our docs.

(`graphql-deduplicator` probably loses schema information, due to its lossy design, which is why I think it was carved out.)

Can you confirm and merge?