### PR TITLE
Update readme to remove unnecessary logic for skipping introspection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -299,7 +299,7 @@ const app = express();
 app.use('/graphql', graphqlExpress(() => {
   return {
     formatResponse: (response) => {
-      if (response.data && !response.data.__schema) {
+      if (response.data) {
         response.data = crunch(response.data);
       }
 
@@ -318,7 +318,7 @@ we recommend conditioning the crunch on a query param, like so:
 app.use('/graphql', graphqlExpress((request) => {
   return {
     formatResponse: (response) => {
-      if(request.query.crunch && response.data && !response.data.__schema) {
+      if(request.query.crunch && response.data) {
         response.data = crunch(response.data);
       }
 


### PR DESCRIPTION
I'm working on a [PR](https://github.com/artsy/metaphysics/pull/1042#issuecomment-389587610) to integration graphql-crunch at Artsy and ran across this part of the docs. Being as it's a hold over from the deduplicator days it'd be nice to remove it to avoid future confusion. 

Thanks for the awesome library!