### PR TITLE
Minor fixup in hash.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-crunch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Normalizes GraphQL responses by reducing duplication, resulting in smaller payloads and faster JSON parsing.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-crunch",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Normalizes GraphQL responses by reducing duplication, resulting in smaller payloads and faster JSON parsing.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/utils/set/hash.js
+++ b/src/utils/set/hash.js
@@ -43,28 +43,30 @@ function hash(value) {
     return intHash(value);
   }
 
+  let code = 0;
+
   if (typeof(value) === 'string') {
-    let code = 0;
+
     const upper = Math.min(value.length, MAX_STRING_LEN);
     for (let i = 0; i < upper; i++) {
-      code += (intHash(i) ^ intHash(value.charCodeAt(i))) % MAX_HASHCODE;
+      code += intHash(i) ^ intHash(value.charCodeAt(i));
     }
-    return code;
-  }
 
-  if (isArray(value)) {
-    let code = 0;
+  } else if (isArray(value)) {
+
     for(let i = 0; i < value.length; i++) {
-      code += (intHash(i) ^ hash(value[i])) % MAX_HASHCODE;
+      code += intHash(i) ^ hash(value[i]);
     }
-    return code;
+
+  } else {
+
+    for (const key in value) {
+      code += hash(key) ^ hash(value[key]);
+    }
+
   }
 
-  let code = 0;
-  for (const key in value) {
-    code += (hash(key) ^ hash(value[key])) % MAX_HASHCODE;
-  }
-  return code;
+  return code % MAX_HASHCODE;
 
 }
 


### PR DESCRIPTION
Moving the `% MAX_HASHCODE` outside of the loop. We're already xor'ing 32-bit values so they'll remain 32-bits. Though the total sum may grow larger, we convert it back to 32-bits before returning.