### PR TITLE
fix(crunch): Fixing when cruncing date object.

### DIFF
--- a/src/utils/containers.js
+++ b/src/utils/containers.js
@@ -1,6 +1,6 @@
 const isArray = Array.isArray;
 
-const isObject = value => (typeof value === 'object' && value !== null);
+const isObject = value => (typeof value === 'object' && value !== null && !(value instanceof Date));
 
 const isContainer = value => isArray(value) || isObject(value);
 


### PR DESCRIPTION
Closed #13

Because of date checked to be an object, the result of crunch data would be always empty object {}.