### PR TITLE
Fix: Arrays could be mistaken for objects in deep object structures

### DIFF
--- a/src/utils/containers.js
+++ b/src/utils/containers.js
@@ -1,6 +1,6 @@
 const isArray = Array.isArray;
 
-const isObject = value => (typeof value === 'object' && value !== null);
+const isObject = value => (typeof value === 'object' && value !== null && !isArray(value));
 
 const isContainer = value => isArray(value) || isObject(value);
 


### PR DESCRIPTION
This tiny change fixes the case where empty arrays could be mistaken for empty objects in large JSON trees. In our case we have a few megabytes JSONs to compare, and started seeing failures for arrays getting deserialised into objects. Why this change works (and the normal code does not), beats me - probably in some cases Array can be distinguished from Object, but if the comparison happens another way around, an empty array can be thought as an object.

I am afraid I cannot provide a test case or even test data to replicate this - the data is customer confidential, and right now my time simply won't suffice to isolate this problem. :(

If you are still willing to check and accept this PR, I'd be grateful. Until then, we will keep on using our fork.