### PR TITLE
Fix for empty objects considered equal empty arrays

### DIFF
--- a/src/utils/set/eq.js
+++ b/src/utils/set/eq.js
@@ -7,11 +7,10 @@ function eq(a, b) {
     return arrayEq(a, b);
   }
 
-  if (aIsArray || bIsArray) {
-    return false;
-  }
-
   if (isObject(a) && isObject(b)) {
+    if (aIsArray || bIsArray) {
+      return false;
+    }
     return objectEq(a, b);
   }
 

--- a/src/utils/set/eq.js
+++ b/src/utils/set/eq.js
@@ -7,10 +7,11 @@ function eq(a, b) {
     return arrayEq(a, b);
   }
 
+  if (aIsArray || bIsArray) {
+    return false;
+  }
+
   if (isObject(a) && isObject(b)) {
-    if (aIsArray || bIsArray) {
-      return false;
-    }
     return objectEq(a, b);
   }
 

--- a/src/utils/set/eq.js
+++ b/src/utils/set/eq.js
@@ -1,20 +1,9 @@
 const { isArray, isObject } = require('../containers');
 
 function eq(a, b) {
-  let aIsArray = isArray(a);
-  let bIsArray = isArray(b);
-  if (aIsArray && bIsArray) {
-    return arrayEq(a, b);
-  }
-
-  if (isObject(a) && isObject(b)) {
-    if (aIsArray || bIsArray) {
-      return false;
-    }
-    return objectEq(a, b);
-  }
-
-  return a === b;
+  return isArray(a) && isArray(b) ? arrayEq(a, b)
+       : isObject(a) && isObject(b) ? objectEq(a, b)
+       : a === b;
 }
 
 function arrayEq(a, b) {

--- a/src/utils/set/eq.js
+++ b/src/utils/set/eq.js
@@ -1,9 +1,20 @@
 const { isArray, isObject } = require('../containers');
 
 function eq(a, b) {
-  return isArray(a) && isArray(b) ? arrayEq(a, b)
-       : isObject(a) && isObject(b) ? objectEq(a, b)
-       : a === b;
+  let aIsArray = isArray(a);
+  let bIsArray = isArray(b);
+  if (aIsArray && bIsArray) {
+    return arrayEq(a, b);
+  }
+
+  if (isObject(a) && isObject(b)) {
+    if (aIsArray || bIsArray) {
+      return false;
+    }
+    return objectEq(a, b);
+  }
+
+  return a === b;
 }
 
 function arrayEq(a, b) {

--- a/test/v1/simple.js
+++ b/test/v1/simple.js
@@ -17,6 +17,7 @@ const baseCases = [
   ['multi-item repeated object', {a: true, b: true, c: true, d: true}, [true, {a: 0, b: 0, c: 0, d: 0}]],
   ['complex array', [{a: true, b: [1, 2, 3]}, [1,2,3]], [true, 1, 2, 3, [1, 2, 3], {a: 0, b: 4}, [5, 4]]],
   ['complex object', {a: true, b: [1, 2, 3], c: {a: true, b: [1,2,3]}}, [true, 1, 2, 3, [1, 2, 3], {a: 0, b: 4}, {a: 0, b: 4, c: 5}]],
+  ['empty object/array', {a: {}, b: []}, [{}, [], {a: 0, b: 1}]],
 ];
 
 baseCases.forEach(([description, uncrunched, crunched]) => {

--- a/test/v2/simple.js
+++ b/test/v2/simple.js
@@ -17,6 +17,7 @@ const baseCases = [
   ['multi-item repeated object', {a: null, b: null, c: null, d: null}, {version: 2, crunched: [{a: null, b: null, c: null, d: null}]}],
   ['complex array', [{a: true, b: [1, 2, 3]}, [1,2,3]], {version: 2, crunched: [[3, 5, 7], 0, [{a: true, b: 0}, 0]]}],
   ['complex object', {a: true, b: [1, 2, 3], c: {a: true, b: [1,2,3]}}, {version: 2, crunched: [[3, 5, 7], 0, {a: true, b: 0, c: {a: true, b: 0}}]}],
+  ['empty object/array', {a: {}, b: []}, {version: 2, crunched: [0, 0, {a: {}, b: []}]}],
 ];
 
 baseCases.forEach(([description, uncrunched, crunched]) => {


### PR DESCRIPTION
```javascript
uncrunch(crunch({ a: {}, b: [] }, 2))
```
Produces incorrect result:
```javascript
{ a: {}, b: {} }
```
This PR fixes this by changing `eq` function.

Empty objects may appear in GraphQL responses with custom scalars like JSON.
Possibly related to #16 