### PR TITLE
Ignore formatting our large JSON blobs used for testing.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,7 @@
 build
 coverage
 node_modules
+
+# Ignore big JSON blobs that aren't meant to be read/modified by humans
+bench/json
+test/json


### PR DESCRIPTION
We have a handful of massive JSON blobs that we use for benchmarking and testing. These aren't intended to be read or maintained by humans, and their size drastically slows down Prettier, so let's just ignore them.