### PR TITLE
Rename `build-test-deploy` Github action to `build-test`.

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -7,7 +7,7 @@ on:
       - created
 
 jobs:
-  build-test-deploy:
+  build-test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
We don't actually deploy in that action, so let's rename it to be clearer. Some future version will actually publish a package.