### PR TITLE
Add code coverage requirements to Jest run.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "test": "yarn build && jest --coverage",
-    "watch": "jest --watchAll --coverage",
+    "test": "yarn build && jest",
+    "watch": "jest --watchAll",
     "bench": "yarn build && node bench/bench.js",
     "build": "./node_modules/typescript/bin/tsc",
     "clean": "rm -rf dist",
@@ -49,7 +49,19 @@
   "jest": {
     "testMatch": [
       "**/dist/test/**/*.js"
-    ]
+    ],
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "**/dist/src/**/*.js"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   },
   "dependencies": {
     "@types/jest": "^27.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,7 @@
 // GraphQL-Crunch is fully backwards-compatible. This module routes into the
 // proper implementation.
 
-const versions = [
-  {
-    crunch: require(`./v1/crunch`),
-    uncrunch: require(`./v1/uncrunch`),
-  },
-  {
-    crunch: require(`./v2/crunch`),
-    uncrunch: require(`./v2/uncrunch`),
-  },
-];
+const versions = [require("./v1"), require("./v2")];
 
 module.exports = {
   crunch: (data, version = 1) =>


### PR DESCRIPTION
We previously collected code coverage, but did not enforce it.

This also modifies our config to collect coverage from all files, whether or not a test executes them.