### PR TITLE
Add caching of `yarn` dependencies between action runs.

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -15,13 +15,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Install yarn
-        run: npm install -g yarn
+          cache: 'yarn'
 
       - name: Install deps
         run: yarn install


### PR DESCRIPTION
Rather than reinstall all dependencies on every action run, let's cache them. Our dependencies rarely change.